### PR TITLE
Disable caching of the rootURL by setting it to false

### DIFF
--- a/lib/service-worker.js
+++ b/lib/service-worker.js
@@ -25,7 +25,7 @@ var BroccoliServiceWorker = function BroccoliServiceWorker(inTree, options) {
   this.networkFirstURLs = options.networkFirstURLs || options.dynamicCache || [];
   this.excludePaths = options.excludePaths || ['tests/*'];
   this.fallback = options.fallback || [];
-  this.rootURL = options.rootURL || '/';
+  this.rootURL = (options.rootURL === false ? false : options.rootURL || '/');
   this.precacheURLs = options.precacheURLs || [];
   if (options.includeRegistration === false) {
     this.includeRegistration = false;
@@ -72,7 +72,9 @@ BroccoliServiceWorker.prototype.write = function(readTree, destDir) {
         lines.push("toolbox.options.debug = true;");
       }
       lines.push("var urlsToPrefetch = [");
-      lines.push("    '"+rootURL+"',");
+      if (rootURL) {
+        lines.push("    '"+rootURL+"',");
+      }
       getFilesRecursively(srcDir, [ "**/*" ]).forEach(function (file, idx, array) {
         lines.push(createArrayLine('    '+JSON.stringify(file), idx, array.length));
       });


### PR DESCRIPTION
At Learning Spaces we don't want the rootURL to be cached because resources are preloaded in the root. By setting it to false we can disable caching the root URL.
